### PR TITLE
add: foreground layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The [Semantic Versioning](https://semver.org/spec/v2.0.0.html) is used.
 
 ## Unreleased - in development
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## 1.0.8
+### Added
 - Added an option to specify a foregroundLayer in the config.json
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The [Semantic Versioning](https://semver.org/spec/v2.0.0.html) is used.
 
 ## Unreleased - in development
 ### Added
+- Added an option to specify a foregroundLayer in the config.json
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This part contains `<gdik-input>` specific parameters. The following properties 
 <dl>
   <dt><b>backgroundLayers</b></dt>
   <dd>List of layer ids defined in services section to be present as background layer in component</dd>
+  <dt><b>foregroundLayer</b></dt>
+  <dd>Layer id defined in services section to be present as the foreground layer in component</dd>
   <dt><b>searchUrl</b></dt>
   <dd>Url of OSGTS to use for geocoding (gdik-search)</dd>
 </dl>
@@ -77,6 +79,7 @@ This part is the content of the [masterportal services.json file](https://www.ma
 {
   "component": {
     "backgroundLayers": ["basemap", "topplus"],
+    "foregroundLayer": "overlay",
     "searchUrl": "https://osgts.example.com"
   },
   "portal": {
@@ -107,6 +110,18 @@ This part is the content of the [masterportal services.json file](https://www.ma
     },
     {
       "id": "topplus",
+      "typ": "WMS",
+      "name": "TopPlusOpen - Farbe",
+      "url": "https://sgx.geodatenzentrum.de/wms_topplus_open",
+      "version": "1.1.1",
+      "layers": "web",
+      "transparent": true,
+      "singleTile": false,
+      "tilesize": 256,
+      "gutter": 20
+    },
+    {
+      "id": "overlay",
       "typ": "WMS",
       "name": "TopPlusOpen - Farbe",
       "url": "https://sgx.geodatenzentrum.de/wms_topplus_open",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@GDIK2022/GDIK-GeoComponent-Suite",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@GDIK2022/GDIK-GeoComponent-Suite",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "EUPL-1.2",
       "dependencies": {
         "masterportalAPI": "bitbucket:geowerkstatt-hamburg/masterportalAPI#v2.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@GDIK2022/GDIK-GeoComponent-Suite",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": {
     "name": "Landesamt für Geoinformation und Landesvermessung Niedersachsen (LGLN)",
     "email": "team-waas@lgln.niedersachsen.de",

--- a/src/components/gcs-draw/drawControl.js
+++ b/src/components/gcs-draw/drawControl.js
@@ -44,7 +44,7 @@ export default class DrawControl extends Control {
         this.featureSource = new VectorSource();
         this.featureLayer = new VectorLayer({source: this.featureSource});
 
-        layerManager.addLayerOnTop(this.featureLayer);
+        layerManager.setInteractionLayer(this.featureLayer);
 
         this.drawInteraction = new Draw({
             type: this.drawType,

--- a/src/components/gcs-layerswitcher/layerswitcherControl.js
+++ b/src/components/gcs-layerswitcher/layerswitcherControl.js
@@ -48,7 +48,7 @@ export default class LayerswitcherControl extends Control {
     render () {
         this.layerContainer.querySelectorAll("*").forEach(n => n.remove());
 
-        this.layerManager.olBackgroundLayer.forEach((layer) => {
+        this.layerManager.backgroundLayers.forEach((layer) => {
             const li = document.createElement("li");
 
             li.className = "list-group-item";

--- a/src/components/gcs-map/GCSMap.js
+++ b/src/components/gcs-map/GCSMap.js
@@ -152,7 +152,7 @@ export default class GCSMap extends HTMLElement {
         config.portal.layers = [];
         map = mapsAPI.map.createMap({...config.portal, layerConf: config.services}, "2D");
 
-        this.layerManager = new LayerManager(map, config.component.backgroundLayers);
+        this.layerManager = new LayerManager(map, config.component.backgroundLayers, config.component?.foregroundLayer);
         this.layerManager.on("backgroudchange", () => {
             this.setAttribute("active-bg", this.layerManager.activeBackgroundLayer.get("id"));
         });

--- a/src/components/gcs-map/LayerManager.js
+++ b/src/components/gcs-map/LayerManager.js
@@ -46,7 +46,6 @@ export default class LayerManager extends Observable {
             layer.set("name", rawLayer.name);
             this.foregroundLayer = layer;
             this.foregroundLayer.setVisible(true);
-            this.foregroundLayer.setOpacity(0.5);
         }
     }
 

--- a/test/components/gcs-map/GCSMap.spec.js
+++ b/test/components/gcs-map/GCSMap.spec.js
@@ -239,5 +239,29 @@ describe("Attribute change related", () => {
         expect(component.getAttribute("active-bg")).toBe(backgroundLayer);
     });
 
-    // TODO check if layermanager is initialized correctly
+});
+
+describe("Reading of config.json", () => {
+
+    it("should initialize LayerManager correctly with foregroundLayer and backgroundLayer", async () => {
+        fetch.mockResponseOnce(JSON.stringify(customConfig)); // customConfig has a foregroundLayer defined
+        const component = new GCSMap();
+
+        component.setAttribute("config-url", "http://config.service/config.json");
+
+        await component.connectedCallback();
+
+        expect(component.layerManager.backgroundLayers.length).toBe(2);
+        expect(component.layerManager.foregroundLayer).not.toBeNull();
+        expect(component.layerManager.foregroundLayer.get("name")).toBe("My WMS");
+    });
+
+    it("should initialize LayerManager correctly without foregroundLayer", async () => {
+        const component = new GCSMap(); // defaultConfig has no foregroundLayer defined
+
+        await component.connectedCallback();
+
+        expect(component.layerManager.backgroundLayers.length).toBe(2);
+        expect(component.layerManager.foregroundLayer).toBeNull();
+    });
 });

--- a/test/components/gcs-map/GCSMap.spec.js
+++ b/test/components/gcs-map/GCSMap.spec.js
@@ -238,4 +238,6 @@ describe("Attribute change related", () => {
 
         expect(component.getAttribute("active-bg")).toBe(backgroundLayer);
     });
+
+    // TODO check if layermanager is initialized correctly
 });

--- a/test/components/gcs-map/LayerManager.spec.js
+++ b/test/components/gcs-map/LayerManager.spec.js
@@ -50,10 +50,10 @@ describe("LayerManager", () => {
 
     it("should create layers from given ids", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1001"],
-            layerManager = new LayerManager(map, backgroundLayers);
+            backgroundLayerIds = ["1001"],
+            layerManager = new LayerManager(map, backgroundLayerIds);
 
-        expect(layerManager.olBackgroundLayer.length).toBe(1);
+        expect(layerManager.backgroundLayers.length).toBe(1);
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("WebAtlasDe");
 
@@ -61,9 +61,9 @@ describe("LayerManager", () => {
 
     it("should create foreground layer from given id", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = [],
-            foregroundLayer = "2003",
-            layerManager = new LayerManager(map, backgroundLayers, foregroundLayer);
+            backgroundLayerIds = [],
+            foregroundLayerId = "2003",
+            layerManager = new LayerManager(map, backgroundLayerIds, foregroundLayerId);
 
         expect(layerManager.foregroundLayer).not.toBeNull();
 
@@ -73,10 +73,10 @@ describe("LayerManager", () => {
 
     it("should create only background layers from given ids", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1001"],
-            layerManager = new LayerManager(map, backgroundLayers);
+            backgroundLayerIds = ["1001"],
+            layerManager = new LayerManager(map, backgroundLayerIds);
 
-        expect(layerManager.olBackgroundLayer.length).toBe(1);
+        expect(layerManager.backgroundLayers.length).toBe(1);
         expect(layerManager.foregroundLayer).toBeNull();
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("WebAtlasDe");
@@ -86,74 +86,87 @@ describe("LayerManager", () => {
     it("should have first given background layer visible", () => {
         const map = mapsAPI.map.createMap();
 
-        let backgroundLayers = ["1001", "1002"],
-            layerManager = new LayerManager(map, backgroundLayers);
+        let backgroundLayerIds = ["1001", "1002"],
+            layerManager = new LayerManager(map, backgroundLayerIds);
 
-        expect(layerManager.olBackgroundLayer.length).toBe(2);
+        expect(layerManager.backgroundLayers.length).toBe(2);
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("WebAtlasDe");
 
-        expect(layerManager.olBackgroundLayer[0].get("name")).toBe("WebAtlasDe");
-        expect(layerManager.olBackgroundLayer[0].getVisible()).toBe(true);
-        expect(layerManager.olBackgroundLayer[1].get("name")).toBe("TopPlusOpen - Farbe");
-        expect(layerManager.olBackgroundLayer[1].getVisible()).toBe(false);
+        expect(layerManager.backgroundLayers[0].get("name")).toBe("WebAtlasDe");
+        expect(layerManager.backgroundLayers[0].getVisible()).toBe(true);
+        expect(layerManager.backgroundLayers[1].get("name")).toBe("TopPlusOpen - Farbe");
+        expect(layerManager.backgroundLayers[1].getVisible()).toBe(false);
 
-        backgroundLayers = ["1002", "1001"];
-        layerManager = new LayerManager(map, backgroundLayers);
+        backgroundLayerIds = ["1002", "1001"];
+        layerManager = new LayerManager(map, backgroundLayerIds);
 
-        expect(layerManager.olBackgroundLayer.length).toBe(2);
+        expect(layerManager.backgroundLayers.length).toBe(2);
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("TopPlusOpen - Farbe");
 
-        expect(layerManager.olBackgroundLayer[0].get("name")).toBe("TopPlusOpen - Farbe");
-        expect(layerManager.olBackgroundLayer[0].getVisible()).toBe(true);
-        expect(layerManager.olBackgroundLayer[1].get("name")).toBe("WebAtlasDe");
-        expect(layerManager.olBackgroundLayer[1].getVisible()).toBe(false);
+        expect(layerManager.backgroundLayers[0].get("name")).toBe("TopPlusOpen - Farbe");
+        expect(layerManager.backgroundLayers[0].getVisible()).toBe(true);
+        expect(layerManager.backgroundLayers[1].get("name")).toBe("WebAtlasDe");
+        expect(layerManager.backgroundLayers[1].getVisible()).toBe(false);
     });
 
     it("should change the active and visible background layer", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1001", "1002"],
-            layerManager = new LayerManager(map, backgroundLayers);
+            backgroundLayersIds = ["1001", "1002"],
+            layerManager = new LayerManager(map, backgroundLayersIds);
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("WebAtlasDe");
-        expect(layerManager.olBackgroundLayer[0].getVisible()).toBe(true);
-        expect(layerManager.olBackgroundLayer[1].getVisible()).toBe(false);
+        expect(layerManager.backgroundLayers[0].getVisible()).toBe(true);
+        expect(layerManager.backgroundLayers[1].getVisible()).toBe(false);
 
         layerManager.changeBackgroundLayer("1002");
 
         expect(layerManager.activeBackgroundLayer.get("name")).toBe("TopPlusOpen - Farbe");
-        expect(layerManager.olBackgroundLayer[0].getVisible()).toBe(false);
-        expect(layerManager.olBackgroundLayer[1].getVisible()).toBe(true);
+        expect(layerManager.backgroundLayers[0].getVisible()).toBe(false);
+        expect(layerManager.backgroundLayers[1].getVisible()).toBe(true);
+    });
+
+    it("should keep the foreground layer on top when changing the active background layer", () => {
+        const map = mapsAPI.map.createMap(),
+            backgroundLayersIds = ["1001", "1002"],
+            foregroundLayerId = "2003",
+            layerManager = new LayerManager(map, backgroundLayersIds, foregroundLayerId);
+
+        expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("My WMS");
+
+        layerManager.changeBackgroundLayer("1002");
+
+        expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("My WMS");
     });
 
     it("should log an error when given background layer id not present", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1003"];
+            backgroundLayerIds = ["1003"];
 
         console.error = jest.fn();
 
-        new LayerManager(map, backgroundLayers);
+        new LayerManager(map, backgroundLayerIds);
 
         expect(console.error.mock.calls[0][0]).toBe("Background layer with id '1003' not found. Skipped.");
     });
 
     it("should log an error when given foreground layer id not present", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = [],
-            foregroundLayer = "2003";
+            backgroundLayerIds = [],
+            foregroundLayerId = "1337";
 
         console.error = jest.fn();
 
-        new LayerManager(map, backgroundLayers, foregroundLayer);
+        new LayerManager(map, backgroundLayerIds, foregroundLayerId);
 
-        expect(console.error.mock.calls[0][0]).toBe("Foreground layer with id '2003' not found.");
+        expect(console.error.mock.calls[0][0]).toBe("Foreground layer with id '1337' not found.");
     });
 
     it("should log an error when changing background layer to a not present id", async () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1002"],
-            layerManager = new LayerManager(map, backgroundLayers);
+            backgroundLayerIds = ["1002"],
+            layerManager = new LayerManager(map, backgroundLayerIds);
 
         console.error = jest.fn();
 
@@ -164,44 +177,73 @@ describe("LayerManager", () => {
         expect(console.error.mock.calls[0][0]).toBe("Background layer with id 1003 not found");
     });
 
-    it("should add layer on top", () => {
+    it("should set the interaction layer on top", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1001", "1002"],
-            layerManager = new LayerManager(map, backgroundLayers),
+            backgroundLayerIds = ["1001", "1002"],
+            layerManager = new LayerManager(map, backgroundLayerIds),
             layerOne = new VectorLayer(),
             layerTwo = new VectorLayer();
 
         layerOne.set("name", "layerOne");
         layerTwo.set("name", "layerTwo");
 
-        layerManager.addLayerOnTop(layerOne);
+        layerManager.setInteractionLayer(layerOne);
 
         expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("layerOne");
 
-        layerManager.addLayerOnTop(layerTwo);
+        layerManager.setInteractionLayer(layerTwo);
         expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("layerTwo");
     });
 
-    it("should add layer on top but 1 below foreground layer", () => {
-        // TODO remove addLayerOnTop and introduce named layer slots (interactionLayer, foregroundLayer, backgroundLayers)
-        // olTopLayer -> interactionLayer, addLayerOnTop -> will be a setter
+    it("should replace the existing interactionLayer with a new one", () => {
         const map = mapsAPI.map.createMap(),
-            backgroundLayers = ["1001", "1002"],
-            foregroundLayer = "1003",
-            layerManager = new LayerManager(map, backgroundLayers, foregroundLayer),
+            backgroundLayerIds = ["1001", "1002"],
+            layerManager = new LayerManager(map, backgroundLayerIds),
             layerOne = new VectorLayer(),
             layerTwo = new VectorLayer();
 
         layerOne.set("name", "layerOne");
         layerTwo.set("name", "layerTwo");
 
-        layerManager.addLayerOnTop(layerOne);
+        layerManager.setInteractionLayer(layerOne);
+
+        expect(map.getLayers().getLength()).toBe(3);
+
+        layerManager.setInteractionLayer(layerTwo);
+        expect(map.getLayers().getLength()).toBe(3);
+    });
+
+    it("should keep the foregroundLayer 1 below the interactionLayer", () => {
+        const map = mapsAPI.map.createMap(),
+            backgroundLayerIds = ["1001", "1002"],
+            foregroundLayerId = "2003",
+            layerManager = new LayerManager(map, backgroundLayerIds, foregroundLayerId),
+            layerOne = new VectorLayer(),
+            layerTwo = new VectorLayer();
+
+        layerOne.set("name", "layerOne");
+        layerTwo.set("name", "layerTwo");
+
+        layerManager.setInteractionLayer(layerOne);
 
         expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("layerOne");
         expect(map.getLayers().item(map.getLayers().getLength() - 2).get("name")).toBe("My WMS");
 
-        layerManager.addLayerOnTop(layerTwo);
+        layerManager.setInteractionLayer(layerTwo);
         expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("layerTwo");
         expect(map.getLayers().item(map.getLayers().getLength() - 2).get("name")).toBe("My WMS");
+    });
+
+    it("should have foreground layer on top", () => {
+        const map = mapsAPI.map.createMap(),
+            backgroundLayerIds = ["1001", "1002"],
+            foregroundLayerId = "2003",
+            layerManager = new LayerManager(map, backgroundLayerIds, foregroundLayerId);
+
+        expect(layerManager.foregroundLayer).not.toBeNull();
+
+        expect(layerManager.foregroundLayer.get("name")).toBe("My WMS");
+        expect(map.getLayers().item(map.getLayers().getLength() - 1).get("name")).toBe("My WMS");
+
     });
 });

--- a/test/components/gcs-map/assets/config.json
+++ b/test/components/gcs-map/assets/config.json
@@ -2,6 +2,7 @@
      "component": {
           "name": "Test config",
           "backgroundLayers": ["1001", "1002"],
+          "foregroundLayer": "1003",
           "searchUrl": "https://osgts.example.com"
      },
      "portal": {

--- a/test/components/gcs-map/assets/config.json
+++ b/test/components/gcs-map/assets/config.json
@@ -2,7 +2,7 @@
      "component": {
           "name": "Test config",
           "backgroundLayers": ["1001", "1002"],
-          "foregroundLayer": "1003",
+          "foregroundLayer": "2003",
           "searchUrl": "https://osgts.example.com"
      },
      "portal": {
@@ -32,6 +32,18 @@
                "id": "1002",
                "typ": "WMS",
                "name": "TopPlusOpen - Farbe",
+               "url": "https://sgx.geodatenzentrum.de/wms_topplus_open",
+               "version": "1.1.1",
+               "layers": "web",
+               "transparent": true,
+               "singleTile": false,
+               "tilesize": 256,
+               "gutter": 20
+          },
+          {
+               "id": "2003",
+               "typ": "WMS",
+               "name": "My WMS",
                "url": "https://sgx.geodatenzentrum.de/wms_topplus_open",
                "version": "1.1.1",
                "layers": "web",


### PR DESCRIPTION
Siehe Beschreibung von Ticket GCS-19.

- LayerManager wurde refactored und hat nun die Slots "backgroundLayers", "foregroundLayer" und "interactionLayer"
- "foregroundLayer" ist ein neues Feature und stell nur einen Overlay-Layer zwischen backgroundLayers und interactionLayer dar.